### PR TITLE
Improve Usability

### DIFF
--- a/assets/plugins/multifields/base/Front.php
+++ b/assets/plugins/multifields/base/Front.php
@@ -86,11 +86,9 @@ class Front
 
                 default:
                     $out = $this->renderData(self::getData(), 0, self::getConfig('templates'));
-                    $out = $out['mf.items'];
+                    $out = $this->tpl(self::getParams('tplWrap'), ['mf.wrap' => $out['mf.items']]);
                     break;
             }
-            
-            $out = $this->tpl(self::getParams('tplWrap'), ['mf.wrap' => $out]);
         }
 
         return $out;

--- a/assets/plugins/multifields/base/Front.php
+++ b/assets/plugins/multifields/base/Front.php
@@ -66,7 +66,11 @@ class Front
         if (!isset($params['tvName'])) {
             $params['tvName'] = '';
         }
-
+        
+        if (!isset($params['tplWrap'])) {
+            $params['tplWrap'] = '@CODE: [+mf.wrap+]';
+        }
+        
         self::setParams($params);
         self::setConfig(null);
         self::setData(null);
@@ -85,6 +89,8 @@ class Front
                     $out = $out['mf.items'];
                     break;
             }
+            
+            $out = $this->tpl(self::getParams('tplWrap'), ['mf.wrap' => $out]);
         }
 
         return $out;


### PR DESCRIPTION
Возможность оборачивать вывод в html код, чанк итд.

Пример: Если на странице показывается блок с галереей и она не заполнена через multifields, то не будет отображаться весь блок. По примеру как в multitv или в doclister. 

Через параметр "tplWrap" можем указать контейнер для вывода с единственным плейсхолдером mf.wrap - он заменится на весь вывод сниппета.
![2023-05-06_16-22-14](https://user-images.githubusercontent.com/54156948/236623749-b8c62f66-f3f3-40c8-9515-2e6bf0cbc22d.jpg)
