### PR TITLE
Update Core.php

### DIFF
--- a/assets/plugins/multifields/base/Core.php
+++ b/assets/plugins/multifields/base/Core.php
@@ -34,7 +34,7 @@ class Core
 
         if (!is_dir($this->getCacheFolder())) {
             mkdir($this->getCacheFolder(), 0755);
-            file_put_contents($this->getCacheFolder() . '.htaccess', "order deny,allow\nallow from all\n");
+            file_put_contents($this->getCacheFolder() . '.htaccess', "<ifModule mod_authz_core.c>\nRequire all granted\n</ifModule>\n<ifModule !mod_authz_core.c>\norder deny,allow\nallow from all\n</ifModule>\n");  
         }
 
         require_once MODX_MANAGER_PATH . 'includes/tmplvars.inc.php';


### PR DESCRIPTION
В общем там трабла с htaccess. тот который делается в cache/multifields по умолчанию, по какойто причине не дает подключаться стилям и js файлам из этой папки в админке. Мне помог вот такой htaccess как я указал тут 

<ifModule mod_authz_core.c>
          Require all granted
</ifModule>
<ifModule !mod_authz_core.c>
         order deny,allow
         allow from all
</ifModule>

Возможно не правильный, но тогда в любом случае надо сделать значит правильный, так как плагин не работает потом в админке и в консоли браузера куча ошибок

Версия ЦМС - 1.4.32
Версия php - 8.2.8
